### PR TITLE
fix the frequency of updating download progress

### DIFF
--- a/lib/services/file_transfer_service.dart
+++ b/lib/services/file_transfer_service.dart
@@ -383,7 +383,7 @@ class FileTransferService {
               updateFileTransferState(
                 fileName,
                 transferId,
-                percent.roundToDouble(),
+                percent,
                 FileState.download,
               );
             }

--- a/lib/view_models/file_progress_provider.dart
+++ b/lib/view_models/file_progress_provider.dart
@@ -24,8 +24,17 @@ class FileProgressProvider extends BaseModel {
 
   updateReceivedFileProgress(
       String transferId, FileTransferProgress fileTransferProgress) {
-    _receivedFileProgress[transferId] = fileTransferProgress;
-    notifyListeners();
+    double? prevPercent = _receivedFileProgress[transferId]?.percent;
+    double? newPercent = fileTransferProgress.percent;
+    double res = 1.0;
+    if (prevPercent != null && newPercent != null) {
+      res = newPercent - prevPercent;
+    }
+    if (res >= 1.0) {
+      fileTransferProgress.percent = fileTransferProgress.percent?.roundToDouble();
+      _receivedFileProgress[transferId] = fileTransferProgress;
+      notifyListeners();
+    }
   }
 
   removeReceiveProgressItem(String transferId) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->


**- What I did - I updated the the provider so that it only updates and notify the listeners when there is a substantial change in download progress(i.e. changes in whole number)**

**- How I did it - By comparing the new change with the current  file transfer progress**

**- How to verify it - while downloading a file, add a print statement that displays the file transfer progress in the provider.**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Instead of listening to every fractional change in download progress, now we only listen to changes in whole numbers (eg. 1%, 2%).