### PR TITLE
chore: update logo and naming to new convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-<img src="https://atsign.dev/assets/img/@dev.png?sanitize=true">
+<img width=250px src="https://atsign.dev/assets/img/atPlatform_logo_gray.svg?sanitize=true">
 
-### Now for a little internet optimism
+[![GitHub License](https://img.shields.io/badge/license-BSD3-blue.svg)](./LICENSE)
 
-# @mosphere PRO
+# atmospherePro
 
 > Peer-to-peer encrypted file sharing has never been easier.
 
-[@mosphere PRO](https://atsign.com/apps/atmosphere/) makes peer-to-peer
+[atmospherePro](https://atsign.com/apps/atmospherepro/) makes peer-to-peer
 encrypted file sharing possible. In real-time, you can send files across
 any device regardless of your location — with the added benefit of total
 privacy. You can fearlessly share contracts, tax information, or other
 confidential information without worrying about your data being stored on
 a server in the cloud.
 
-This repo holds the open source code for the @mosphere PRO app, to serve as
+This repo holds the open source code for the atmospherePro app, to serve as
 an example of apps that can be build on the atPlatform.
 
 ## Developer
@@ -23,5 +23,5 @@ with the atPlatform. So if you're a developer take a look at the code here.
 
 ### Contributor
 
-If you've got suggestions for making @mosphere PRO better then we :heart:
+If you've got suggestions for making atmospherePro better then we :blue_heart:
 issues and pull requests.


### PR DESCRIPTION
README hasn't yet been updated to use new branding and naming conventions

**- What I did**

Pasted in logo and badge from at_server
s/@ mosphere PRO/atmospherePro/ to match https://atsign.com/apps/atmospherepro/

**- Description for the changelog**

chore: update logo and naming to new convention