### PR TITLE
fix: Set AtClientPreference.enforceNamespace to `false` temporarily

### DIFF
--- a/lib/services/backend_service.dart
+++ b/lib/services/backend_service.dart
@@ -35,9 +35,6 @@ import 'package:flutter/services.dart';
 import 'package:path_provider/path_provider.dart' as path_provider;
 import 'package:provider/provider.dart';
 import 'navigation_service.dart';
-import 'package:at_client/src/service/sync_service.dart';
-import 'package:at_client/src/service/notification_service_impl.dart';
-import 'package:at_client/src/service/notification_service.dart';
 import 'package:at_sync_ui_flutter/at_sync_ui_flutter.dart';
 
 class BackendService {
@@ -112,7 +109,9 @@ class BackendService {
       ..syncRegex = MixedConstants.regex
       ..outboundConnectionTimeout = MixedConstants.TIME_OUT
       ..monitorHeartbeatInterval = Duration(minutes: 1)
-      ..hiveStoragePath = path;
+      ..hiveStoragePath = path
+      // ignore: deprecated_member_use
+      ..enforceNamespace = false;
     return _atClientPreference;
   }
 
@@ -182,7 +181,7 @@ class BackendService {
         .contains(MixedConstants.FILE_TRANSFER_ACKNOWLEDGEMENT)) {
       var decryptedMessage = response.value!;
 
-      if (decryptedMessage != null && decryptedMessage != '') {
+      if (decryptedMessage != '') {
         DownloadAcknowledgement downloadAcknowledgement =
             DownloadAcknowledgement.fromJson(jsonDecode(decryptedMessage));
 
@@ -202,7 +201,7 @@ class BackendService {
       //TODO: only for testing
       // await sendNotificationAck(notificationKey, fromAtSign);
 
-      if (decryptedMessage != null && decryptedMessage != '') {
+      if (decryptedMessage != '') {
         await Provider.of<HistoryProvider>(NavService.navKey.currentContext!,
                 listen: false)
             .checkForUpdatedOrNewNotification(fromAtSign, decryptedMessage);
@@ -242,6 +241,7 @@ class BackendService {
         ..metadata!.ttr = -1
         ..metadata!.ttl = 518400000;
 
+      // ignore: unused_local_variable
       var notificationResult =
           await AtClientManager.getInstance().notificationService.notify(
                 NotificationParams.forUpdate(
@@ -281,7 +281,7 @@ class BackendService {
       primaryColor: ColorConstants.orangeColor,
     );
 
-    await AtSyncUIService().sync();
+    AtSyncUIService().sync();
   }
 
   _onSuccessCallback(SyncResult syncStatus) async {
@@ -355,7 +355,7 @@ class BackendService {
                 onTap: () async {
                   ScaffoldMessenger.of(NavService.navKey.currentContext!)
                       .hideCurrentSnackBar();
-                  await AtSyncUIService().sync();
+                  AtSyncUIService().sync();
                 },
                 child: Text(TextStrings().retry,
                     style: CustomTextStyles.whiteBold16),
@@ -462,6 +462,7 @@ class BackendService {
       //  await getAtClientPreference();
       await getAtClientPreference()
           .then((value) => atClientPrefernce = value)
+          // ignore: invalid_return_type_for_catch_error
           .catchError((e) => print(e));
 
       authenticating = false;
@@ -589,7 +590,7 @@ class BackendService {
         MaterialPageRoute(builder: (context) => HistoryScreen(tabIndex: 1)),
       );
     } else if (Platform.isMacOS) {
-      DesktopSetupRoutes.nested_push(DesktopRoutes.DESKTOP_HISTORY);
+      await DesktopSetupRoutes.nested_push(DesktopRoutes.DESKTOP_HISTORY);
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,7 +67,8 @@ dependencies:
   at_contact: ^3.0.7
   at_common_flutter: ^2.0.8
 
-  at_client_mobile: ^3.2.1
+  at_client_mobile: ^3.2.3+1
+  at_client: ^3.0.34
   at_onboarding_flutter: ^4.0.4
   at_backupkey_flutter: ^4.0.3
   at_contacts_flutter: ^4.0.5


### PR DESCRIPTION
**- What I did**
* fix: Set AtClientPreference.enforceNamespace to `false` as a temporary fix until AtmospherePro ensures all keys it creates are created with namespaces
* build: take up at_client ^3.0.34 which added the new `enforceNamespace` option to AtClientPreference

**- Background**
* AtmospherePro creates some keys without namespaces, I believe for notifications. Following recent changes in the core SDK, the namespace enforcement is now working as intended. As a result, AtmospherePro not working properly
* This PR is to allow the app to continue to work
* What needs to happen is AtmospherePro needs to ensure that all keys are created with a namespace. However this requires backwards / forwards compatibility testing between versions of AtmospherePro - i.e. will current store versions of AtmospherePro (some keys without namespace) be able to send files to, and receive files from, a fixed version of AtmospherePro (all keys have namespace)

**- How to verify it**
* **NOTE** As of time of writing, you will need to use `flutter channel beta` in order to pick up latest version of flutter_test, as @gkc pushed changes in at_client and at_persistence_secondary_server requiring meta ^1.8.0 and flutter_test in the `stable` channel requires 1.7.0

**- Description for the changelog**
* fix: Set AtClientPreference.enforceNamespace to `false` as a temporary fix until AtmospherePro ensures all keys it creates are created with namespaces
* build: take up at_client ^3.0.34 which added the new `enforceNamespace` option to AtClientPreference
