### PR TITLE
fix: start monitor removed from syncSuccesCallback

### DIFF
--- a/lib/services/backend_service.dart
+++ b/lib/services/backend_service.dart
@@ -285,8 +285,6 @@ class BackendService {
   }
 
   _onSuccessCallback(SyncResult syncStatus) async {
-    await startMonitor();
-
     // removes failed snackbar message.
     ScaffoldMessenger.of(NavService.navKey.currentContext!)
         .hideCurrentSnackBar();
@@ -535,6 +533,7 @@ class BackendService {
         .resetData();
 
     await KeychainUtil.makeAtSignPrimary(onboardedAtsign);
+    startMonitor();
     syncWithSecondary();
 
     // start monitor and package initializations.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- removed start monitor from successCallback and added when onboard success.
Earlier syncSuccess was getting called multiple times and it creates multiple listeners.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->